### PR TITLE
Bump log4j-core from 2.13.2 to 2.17.1 in /iot-device-sdk-java

### DIFF
--- a/iot-device-sdk-java/pom.xml
+++ b/iot-device-sdk-java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.17.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps log4j-core from 2.13.2 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>